### PR TITLE
Implement SelfValidating

### DIFF
--- a/inspector-compiler/src/main/java/io/sweers/inspector/compiler/InspectorProcessor.java
+++ b/inspector-compiler/src/main/java/io/sweers/inspector/compiler/InspectorProcessor.java
@@ -19,6 +19,7 @@ import com.squareup.javapoet.TypeVariableName;
 import com.squareup.javapoet.WildcardTypeName;
 import io.sweers.inspector.Inspector;
 import io.sweers.inspector.InspectorIgnored;
+import io.sweers.inspector.SelfValidating;
 import io.sweers.inspector.Types;
 import io.sweers.inspector.ValidatedBy;
 import io.sweers.inspector.ValidationException;
@@ -51,6 +52,8 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.type.MirroredTypeException;
+import javax.lang.model.type.NoType;
+import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
 import javax.lang.model.util.Elements;
@@ -68,12 +71,14 @@ import static javax.lang.model.element.Modifier.STATIC;
   private Messager messager;
   private Filer filer;
   private Elements elements;
+  private javax.lang.model.util.Types typeUtils;
 
   @Override public synchronized void init(ProcessingEnvironment processingEnv) {
     super.init(processingEnv);
     messager = processingEnv.getMessager();
     filer = processingEnv.getFiler();
     elements = processingEnv.getElementUtils();
+    typeUtils = processingEnv.getTypeUtils();
   }
 
   @Override public SourceVersion getSupportedSourceVersion() {
@@ -102,7 +107,48 @@ import static javax.lang.model.element.Modifier.STATIC;
     return false;
   }
 
+  @SuppressWarnings("Duplicates") private boolean implementsSelfValidating(TypeElement type) {
+    TypeMirror validatorFactoryType =
+        elements.getTypeElement(SelfValidating.class.getCanonicalName())
+            .asType();
+    TypeMirror typeMirror = type.asType();
+    if (!type.getInterfaces()
+        .isEmpty() || typeMirror.getKind() != TypeKind.NONE) {
+      while (typeMirror.getKind() != TypeKind.NONE) {
+        if (searchInterfacesAncestry(typeMirror, validatorFactoryType)) {
+          return true;
+        }
+        type = (TypeElement) typeUtils.asElement(typeMirror);
+        typeMirror = type.getSuperclass();
+      }
+    }
+    return false;
+  }
+
+  @SuppressWarnings("Duplicates")
+  private boolean searchInterfacesAncestry(TypeMirror rootIface, TypeMirror target) {
+    TypeElement rootIfaceElement = (TypeElement) typeUtils.asElement(rootIface);
+    // check if it implements valid interfaces
+    for (TypeMirror iface : rootIfaceElement.getInterfaces()) {
+      TypeElement ifaceElement = (TypeElement) typeUtils.asElement(rootIface);
+      while (iface.getKind() != TypeKind.NONE) {
+        if (typeUtils.isSameType(iface, target)) {
+          return true;
+        }
+        // go up
+        if (searchInterfacesAncestry(iface, target)) {
+          return true;
+        }
+        // then move on
+        iface = ifaceElement.getSuperclass();
+      }
+    }
+    return false;
+  }
+
   private boolean applicable(TypeElement type) {
+    boolean isSelfValidating = implementsSelfValidating(type);
+
     // check that the class contains a public static method returning a Validator
     TypeName typeName = TypeName.get(type.asType());
     ParameterizedTypeName validatorType =
@@ -115,7 +161,7 @@ import static javax.lang.model.element.Modifier.STATIC;
         TypeMirror rType = method.getReturnType();
         TypeName returnType = TypeName.get(rType);
         if (returnType.equals(validatorType)) {
-          return true;
+          return checkSelfValidating(isSelfValidating, type);
         }
 
         if (returnType.equals(validatorType.rawType) || (returnType instanceof ParameterizedTypeName
@@ -138,7 +184,7 @@ import static javax.lang.model.element.Modifier.STATIC;
       if (typeName instanceof ParameterizedTypeName) {
         ParameterizedTypeName pTypeName = (ParameterizedTypeName) typeName;
         if (pTypeName.rawType.equals(argument)) {
-          return true;
+          return checkSelfValidating(isSelfValidating, type);
         }
       } else {
         messager.printMessage(Diagnostic.Kind.WARNING,
@@ -152,6 +198,18 @@ import static javax.lang.model.element.Modifier.STATIC;
     }
 
     return false;
+  }
+
+  private boolean checkSelfValidating(boolean isSelfValidating,
+      TypeElement type) {
+    if (isSelfValidating) {
+      messager.printMessage(Diagnostic.Kind.WARNING,
+          String.format("Found public static method returning Validator on %s class, but "
+                  + "it also implements SelfValidating. Skipping InspectorValidator generation.",
+              type));
+      return false;
+    }
+    return true;
   }
 
   private Map<String, ExecutableElement> getProperties(TypeElement targetClass) {
@@ -400,6 +458,11 @@ import static javax.lang.model.element.Modifier.STATIC;
   private static List<Property> readProperties(Map<String, ExecutableElement> properties) {
     List<Property> values = new ArrayList<>();
     for (Map.Entry<String, ExecutableElement> entry : properties.entrySet()) {
+      if (entry.getValue()
+          .getReturnType() instanceof NoType) {
+        // Covers things like void types
+        continue;
+      }
       values.add(new Property(entry.getKey(), entry.getValue()));
     }
     return values;

--- a/inspector-compiler/src/main/java/io/sweers/inspector/compiler/InspectorProcessor.java
+++ b/inspector-compiler/src/main/java/io/sweers/inspector/compiler/InspectorProcessor.java
@@ -77,7 +77,7 @@ import static javax.lang.model.element.Modifier.STATIC;
   }
 
   @Override public SourceVersion getSupportedSourceVersion() {
-    return SourceVersion.RELEASE_8;
+    return SourceVersion.latestSupported();
   }
 
   @Override public Set<String> getSupportedAnnotationTypes() {

--- a/inspector-compiler/src/test/java/io/sweers/inspector/compiler/InspectorProcessorTest.java
+++ b/inspector-compiler/src/test/java/io/sweers/inspector/compiler/InspectorProcessorTest.java
@@ -1,12 +1,18 @@
 package io.sweers.inspector.compiler;
 
+import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
 import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 import javax.tools.JavaFileObject;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertAbout;
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.testing.compile.Compiler.javac;
 import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
+import static javax.tools.JavaFileObject.Kind.SOURCE;
 
 public final class InspectorProcessorTest {
 
@@ -21,5 +27,40 @@ public final class InspectorProcessorTest {
         .compilesWithoutError()
         .and()
         .generatesSources(JavaFileObjects.forResource("Validator_Person.java"));
+  }
+
+  @Test public void shouldIgnoreIfImplementsSelfValidating() {
+    Compilation compilation = javac().withClasspathFrom(getClass().getClassLoader())
+        .withProcessors(new InspectorProcessor())
+        .compile(JavaFileObjects.forSourceLines("test.SelfValidatingFoo",
+            "package test;\n"
+                + "\n"
+                + "import com.google.auto.value.AutoValue;\n"
+                + "import io.sweers.inspector.Inspector;\n"
+                + "import io.sweers.inspector.SelfValidating;\n"
+                + "import io.sweers.inspector.ValidationException;\n"
+                + "import io.sweers.inspector.Validator;\n"
+                + "\n"
+                + "@AutoValue abstract class SelfValidatingFoo implements SelfValidating {\n"
+                + "  @Override public final void validate(Inspector inspector) throws "
+                + "ValidationException {\n"
+                + "    // Custom validation!\n"
+                + "  }\n"
+                + "  \n"
+                + "  public static Validator<SelfValidatingFoo> validator(Inspector inspector) {\n"
+                + "    return new Validator<SelfValidatingFoo>() {\n"
+                + "      @Override public void validate(SelfValidatingFoo selfValidatingFoo)\n"
+                + "          throws ValidationException {\n"
+                + "        \n"
+                + "      }\n"
+                + "    };\n"
+                + "  }\n"
+                + "}"));
+
+    List<JavaFileObject> generatedJavaFiles = compilation.generatedSourceFiles()
+        .stream()
+        .filter(javaFileObject -> javaFileObject.getKind() == SOURCE)
+        .collect(Collectors.toList());
+    assertThat(generatedJavaFiles).isEmpty();
   }
 }

--- a/inspector/src/main/java/io/sweers/inspector/Inspector.java
+++ b/inspector/src/main/java/io/sweers/inspector/Inspector.java
@@ -22,6 +22,7 @@ public final class Inspector {
     BUILT_IN_FACTORIES.add(CollectionValidator.FACTORY);
     BUILT_IN_FACTORIES.add(MapValidator.FACTORY);
     BUILT_IN_FACTORIES.add(ArrayValidator.FACTORY);
+    BUILT_IN_FACTORIES.add(SelfValidating.FACTORY);
     BUILT_IN_FACTORIES.add(ClassValidator.FACTORY);
   }
 

--- a/inspector/src/main/java/io/sweers/inspector/SelfValidating.java
+++ b/inspector/src/main/java/io/sweers/inspector/SelfValidating.java
@@ -1,0 +1,49 @@
+package io.sweers.inspector;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/**
+ * An interface that a given type can implement to let Inspector know that it validates itself.
+ *
+ * <pre><code>
+ *   class Foo implements SelfValidating {
+ *      {@literal @}Override public void validate(Inspector inspector) throws ValidationException {
+ *        // Implement custom validation logic here.
+ *      }
+ *   }
+ * </code></pre>
+ */
+public interface SelfValidating {
+  /**
+   * Validates this object with whatever custom validation implementation the user wants.
+   *
+   * @throws ValidationException upon invalidation
+   */
+  void validate(Inspector inspector) throws ValidationException;
+
+  /**
+   * A factory instance for this. This is not considered public API.
+   */
+  Validator.Factory FACTORY = new Validator.Factory() {
+
+    @Nullable @Override public Validator<?> create(final Type type,
+        final Set<? extends Annotation> annotations,
+        final Inspector inspector) {
+      if (SelfValidating.class.isAssignableFrom(Types.getRawType(type))) {
+        return new Validator<SelfValidating>() {
+          @Override public void validate(SelfValidating target) throws ValidationException {
+            target.validate(inspector);
+          }
+
+          @Override public String toString() {
+            return "SelfValidating(" + Types.typeToString(type) + ")";
+          }
+        };
+      }
+      return null;
+    }
+  };
+}

--- a/inspector/src/test/java/io/sweers/inspector/InspectorTest.java
+++ b/inspector/src/test/java/io/sweers/inspector/InspectorTest.java
@@ -1,10 +1,12 @@
 package io.sweers.inspector;
 
+import io.sweers.inspector.InspectorTest.SelfValidatingType.NestedInheritedSelfValidating;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.sweers.inspector.InspectorTest.SelfValidatingType.VALIDATION_MESSAGE;
 import static junit.framework.TestCase.fail;
 
 public final class InspectorTest {
@@ -34,6 +36,44 @@ public final class InspectorTest {
   public static class Data {
     public String thing() {
       return null;
+    }
+  }
+
+  @Test public void testSelfValidating() {
+    Inspector inspector = new Inspector.Builder()
+        .build();
+
+    SelfValidatingType selfValidatingType = new SelfValidatingType();
+
+    try {
+      inspector.validator(SelfValidatingType.class).validate(selfValidatingType);
+      fail("This should throw a validation exception!");
+    } catch (ValidationException e) {
+      assertThat(e).hasMessageThat().isEqualTo(VALIDATION_MESSAGE);
+    }
+
+    NestedInheritedSelfValidating nested = new NestedInheritedSelfValidating();
+
+    try {
+      inspector.validator(NestedInheritedSelfValidating.class).validate(nested);
+      fail("This should throw a validation exception!");
+    } catch (ValidationException e) {
+      assertThat(e).hasMessageThat().isEqualTo(VALIDATION_MESSAGE);
+    }
+  }
+
+  interface InheritedSelfValidating extends SelfValidating {
+
+  }
+
+  static class SelfValidatingType implements InheritedSelfValidating {
+    static final String VALIDATION_MESSAGE = "This should fail!";
+    @Override public void validate(Inspector inspector) throws ValidationException {
+      throw new ValidationException(VALIDATION_MESSAGE);
+    }
+
+    static class NestedInheritedSelfValidating extends SelfValidatingType {
+
     }
   }
 


### PR DESCRIPTION
This implements support for `SelfValidating`, an interface that can just be used as a sentinel to Inspector to indicate that this type validates itself. This is useful for cases where you have very custom validation logic, potentially just very little, or if one code gens their own objects and wants to inline validation logic.

This also has a couple opportunistic fixes, namely to ignore `void` return types as properties and use the latest source version for the annotation processor

Resolves #1 